### PR TITLE
Add bin/atlas-skeleton.php to composer bin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,6 @@
         "psr-4": {
             "Atlas\\Cli\\": "tests/"
         }
-    }
+    },
+    "bin":["bin/atlas-skeleton.php"]
 }


### PR DESCRIPTION
Make it so I can get at the bin from `./vendor/bin/` rather than `./vendor/atlas/cli/bin`
