### PR TITLE
Stop looking for templates when one is found

### DIFF
--- a/src/Skeleton/Skeleton.php
+++ b/src/Skeleton/Skeleton.php
@@ -204,6 +204,7 @@ class Skeleton
                 $file = $dir. DIRECTORY_SEPARATOR . $class . '.tpl';
                 if ($this->fsio->isFile($file)) {
                     $this->templates[$class] = $this->fsio->get($file);
+                    continue 2;
                 }
             }
         }


### PR DESCRIPTION
> If a custom template is found, the loop looking for templates should move on to
> the next classname, rather than continue searching directories. Otherwise the
> default template will overwrite the custom template even if the custom template
> is present.

Perhaps I'm missing something.
It seems to me that if I pass a `--tpl=./custom/templates`, the loop will look there first, find it, read it, then continue to check the default directory, find that one, read it, and overwrite the custom template, no?
