### PR TITLE
Add support to have database specified with table name

### DIFF
--- a/src/Skeleton/Skeleton.php
+++ b/src/Skeleton/Skeleton.php
@@ -227,13 +227,18 @@ class Skeleton
         ];
 
         $table = $this->input->table;
+        $database = null;
+        $cleanTable = $table;
+
         if (! $table) {
             return;
+        } elseif (strpos($table, '.')) {
+            list($database, $cleanTable) = explode('.', $table, 2);
         }
 
         $schema = $this->newSchema();
-        $tables = $schema->fetchTableList();
-        if (! in_array($table, $tables)) {
+        $tables = $schema->fetchTableList($database);
+        if (! in_array($cleanTable, $tables)) {
             $this->logger->error("-Failure: table '{$table}' not found.");
             return Status::FAILURE;
         }

--- a/tests/Skeleton/SkeletonTest.php
+++ b/tests/Skeleton/SkeletonTest.php
@@ -71,6 +71,27 @@ class SkeletonTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->fsio->isFile('/app/DataSource/Author/AuthorTableEvents.php'));
     }
 
+    public function testTableWithDatabase()
+    {
+        $this->assertFalse($this->fsio->isFile('/app/DataSource/Author/AuthorMapper.php'));
+        $this->assertFalse($this->fsio->isFile('/app/DataSource/Author/AuthorTable.php'));
+
+        $this->fsio->mkdir('/app/DataSource');
+
+        $input = $this->factory->newSkeletonInput();
+        $input->dir = '/app/DataSource';
+        $input->namespace = 'App\\DataSource\\Author';
+        $input->conn = ['sqlite:' . dirname(__DIR__) . DIRECTORY_SEPARATOR . 'fixture.sqlite'];
+        $input->table = 'main.authors';
+
+        $skeleton = $this->factory->newSkeleton();
+        $skeleton($input);
+
+        $this->assertTrue($this->fsio->isFile('/app/DataSource/Author/AuthorMapper.php'));
+        $this->assertTrue($this->fsio->isFile('/app/DataSource/Author/AuthorTable.php'));
+        $this->assertContains('main.authors', $this->fsio->get('/app/DataSource/Author/AuthorTable.php'));
+    }
+
     public function testFactoryWithConnection()
     {
         $conn = ['sqlite:' . dirname(__DIR__) . DIRECTORY_SEPARATOR . 'fixture.sqlite'];


### PR DESCRIPTION
Add an option to have the database name with the table name when you use one connection to multiple databases