### PR TITLE
Handle words ending in double 's'

### DIFF
--- a/src/Transform.php
+++ b/src/Transform.php
@@ -23,7 +23,6 @@ class Transform
         'fish',
         'information',
         'money',
-        'press',
         'rice',
         'series',
         'sheep',
@@ -64,7 +63,7 @@ class Transform
         '/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => '$1$2sis',
         '/([ti])a$/i' => '$1um',
         '/(n)ews$/i' => '$1ews',
-        '/s$/i' => ''
+        '/s[1]$/i' => ''
     ];
 
     /**


### PR DESCRIPTION
* Makes the regex for "ending in 's'" to be, more specifically, "ending in a single 's'" so that words like _address_, _class_, _illness_, _pass_, _press_, etc. are not unexpectedly truncated. Also removes the (now obsolete) exception "press" from the list.