### PR TITLE
Fix property return type for ManyToMany

### DIFF
--- a/src/Skeleton.php
+++ b/src/Skeleton.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Atlas\Cli;
 
 use Atlas\Info\Info;
+use Atlas\Mapper\Relationship\ManyToMany;
 use Atlas\Pdo\Connection;
 use Atlas\Mapper\MapperLocator;
 use Atlas\Mapper\Relationship\OneToMany;
@@ -282,6 +283,7 @@ class Skeleton
             $foreignMapperClass = $rprop->getValue($def);
             switch (true) {
                 case $def instanceof OneToMany:
+                case $def instanceof ManyToMany:
                     $type = "null|\\{$foreignMapperClass}RecordSet";
                     break;
                 case $def instanceof ManyToOneVariant:


### PR DESCRIPTION
Currently the generated code says a many to many relationship returns a `Record` and that's wrong it should says it returns a `RecordSet`

As seen here:
https://github.com/atlasphp/Atlas.Testing/blob/543bd3271d9311e1443986790e7eeca226a3097d/src/DataSource/Thread/ThreadFields.php#L18

This fixes this by adding `ManyToMany` to the switch statment